### PR TITLE
Fix seed handling and parallel bookkeeping issues

### DIFF
--- a/R/LS.dynamic.R
+++ b/R/LS.dynamic.R
@@ -36,50 +36,67 @@ LS.dynamic <- function(object, time.col, feature = NULL, assay = "RNA", slot = "
   if (!(time.col %in% colnames(md))) stop(paste("Metadata column", time.col, "not found."))
   time.vec <- md[[time.col]]
   expr.mat <- Seurat::GetAssayData(object, assay = assay, slot = slot)
-  removed.counts <- setNames(integer(length(feature)), feature)
-
-  process_features <- function(feats) {
-    lapply(feats, function(feat) {
-      if (!(feat %in% rownames(expr.mat))) {
-        warning(paste("Feature", feat, "not found; skipped.")); return(NULL)
-      }
-      sig.vec <- as.numeric(expr.mat[feat, ])
-      keep <- is.finite(time.vec) & is.finite(sig.vec)
-      removed.counts[feat] <<- sum(!keep)
-      tvec <- time.vec[keep]; svec <- sig.vec[keep]
-      ord <- order(tvec); tvec <- tvec[ord]; svec <- svec[ord]
-      N <- length(tvec)
-      if (!is.null(window.func)) {
-        wf <- match.fun(window.func); wv <- wf(N)
-      } else {
-        wv <- rep(1, N)
-      }
-      ywin <- svec * wv
-      if (center) ywin <- ywin - mean(ywin)
-      t.py <- np$array(tvec); y.py <- np$array(ywin)
-      freqs <- np$linspace(f.min, f.max, as.integer(n.bins))
-      ls.obj <- ats$LombScargle(t.py, y.py)
-      power <- ls.obj$power(freqs)
-      fap.vec <- ls.obj$false_alarm_probability(power, method = fap.method)
-      freq.r <- py_to_r(freqs); fap.r <- py_to_r(fap.vec)
-      idx <- which.max(power)
-      tibble::tibble(Feature = feat,
-                     PeakFrequency = freq.r[idx],
-                     PeakFAP = fap.r[idx])
-    })
+  process_feature <- function(feat) {
+    removed <- setNames(0L, feat)
+    if (!(feat %in% rownames(expr.mat))) {
+      warning(paste("Feature", feat, "not found; skipped."))
+      return(list(result = NULL, removed = removed))
+    }
+    sig.vec <- as.numeric(expr.mat[feat, ])
+    keep <- is.finite(time.vec) & is.finite(sig.vec)
+    removed[] <- sum(!keep)
+    if (!any(keep)) {
+      warning(paste("Feature", feat, "has no finite observations after filtering; skipped."))
+      return(list(result = NULL, removed = removed))
+    }
+    tvec <- time.vec[keep]; svec <- sig.vec[keep]
+    ord <- order(tvec); tvec <- tvec[ord]; svec <- svec[ord]
+    N <- length(tvec)
+    if (!is.null(window.func)) {
+      wf <- match.fun(window.func); wv <- wf(N)
+    } else {
+      wv <- rep(1, N)
+    }
+    ywin <- svec * wv
+    if (center) ywin <- ywin - mean(ywin)
+    t.py <- np$array(tvec); y.py <- np$array(ywin)
+    freqs <- np$linspace(f.min, f.max, as.integer(n.bins))
+    ls.obj <- ats$LombScargle(t.py, y.py)
+    power <- ls.obj$power(freqs)
+    fap.vec <- ls.obj$false_alarm_probability(power, method = fap.method)
+    freq.r <- py_to_r(freqs); fap.r <- py_to_r(fap.vec)
+    idx <- which.max(power)
+    tib <- tibble::tibble(
+      Feature = feat,
+      PeakFrequency = freq.r[idx],
+      PeakFAP = fap.r[idx]
+    )
+    list(result = tib, removed = removed)
   }
 
   if (n.cores > 1) {
-    chunks <- split(feature, cut(seq_along(feature), breaks = n.cores, labels = FALSE))
-    res_list <- parallel::mclapply(chunks, process_features, mc.cores = n.cores)
-    res_flat <- do.call(c, res_list)
+    res_list <- parallel::mclapply(feature, process_feature, mc.cores = n.cores)
   } else {
-    res_flat <- process_features(feature)
+    res_list <- lapply(feature, process_feature)
   }
 
-  total_removed <- sum(removed.counts);
-  n_feats <- sum(removed.counts > 0);
+  removed.list <- lapply(res_list, function(x) x$removed)
+  if (length(removed.list) > 0) {
+    removed.counts <- unlist(removed.list, use.names = TRUE)
+  } else {
+    removed.counts <- setNames(integer(0), character(0))
+  }
+  res_flat <- lapply(res_list, function(x) x$result)
+  res_flat <- Filter(Negate(is.null), res_flat)
+
+  total_removed <- sum(removed.counts)
+  n_feats <- sum(removed.counts > 0)
   if (total_removed > 0) message(paste(total_removed, "NA/Inf removed across", n_feats, "features"))
-  results <- do.call(dplyr::bind_rows, res_flat)
+
+  if (!length(res_flat)) {
+    return(tibble::tibble(Feature = character(), PeakFrequency = numeric(), PeakFAP = numeric()))
+  }
+
+  results <- dplyr::bind_rows(res_flat)
   return(results)
 }

--- a/R/LS.plot.R
+++ b/R/LS.plot.R
@@ -26,7 +26,11 @@ LS.plot <- function(object, time.col, feature,
   md <- object@meta.data
   if (!(time.col %in% colnames(md))) stop(paste("Metadata column", time.col, "not found."))
   time.vec <- md[[time.col]]
-  expr.vec <- as.numeric(Seurat::GetAssayData(object, assay = assay, slot = slot)[feature, ])
+  expr.mat <- Seurat::GetAssayData(object, assay = assay, slot = slot)
+  if (!(feature %in% rownames(expr.mat))) {
+    stop(sprintf("Feature '%s' not found in assay '%s'.", feature, assay))
+  }
+  expr.vec <- as.numeric(expr.mat[feature, ])
   keep <- is.finite(time.vec) & is.finite(expr.vec)
   tvec <- time.vec[keep]; svec <- expr.vec[keep]
   ord <- order(tvec); tvec <- tvec[ord]; svec <- svec[ord]

--- a/R/LS.shift.R
+++ b/R/LS.shift.R
@@ -40,7 +40,9 @@ LS.shift <- function(object, time.col1, time.col2, features = NULL, assay = "RNA
   if (!requireNamespace("reticulate", quietly = TRUE)) stop("Package 'reticulate' is required.")
   if (!requireNamespace("parallel", quietly = TRUE)) stop("Package 'parallel' is required for n.cores > 1.")
 
-  set.seed(seed)
+  if (!is.null(seed)) {
+    set.seed(seed)
+  }
   np <- reticulate::import("numpy")
   if (!is.null(seed) && !is.null(np$random)) np$random$seed(as.integer(seed))
   np$seterr(divide = "ignore", invalid = "ignore")


### PR DESCRIPTION
## Summary
- guard `LS.shift()` against NULL seeds so users can opt out of deterministic shuffling
- refactor `LS.dynamic()` to track removed-value counts via return values, keeping the tallies correct under parallel execution and skipping empty features gracefully
- validate the requested feature name in `LS.plot()` to provide a friendly error when the gene is absent

## Testing
- Rscript -e 'source("R/LS.shift.R"); source("R/LS.dynamic.R"); source("R/LS.plot.R")' *(fails: Rscript unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce2fe2b08083339aba440b7e3a33cb